### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This project is a Model Context Protocol (MCP) server for performing enrichment 
 
 This tool provides a simple MCP server implementation to perform third-party enrichment using common services (e.g. VirusTotal, Hybrid Analysis, etc.) utilizing the [security-cli](https://github.com/MSAdministrator/security-cli) python package to perform enrichment/communicate with different services.
 
+<a href="https://glama.ai/mcp/servers/@MSAdministrator/enrichment-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@MSAdministrator/enrichment-mcp/badge" alt="Enrichment Server MCP server" />
+</a>
+
 ## MCP Server
 
 This implementation of the `enrichment-mcp` MCP server exposes the following [tools](https://modelcontextprotocol.io/docs/concepts/tools).


### PR DESCRIPTION
This PR adds a badge for the [Enrichment MCP Server](https://glama.ai/mcp/servers/@MSAdministrator/enrichment-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@MSAdministrator/enrichment-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@MSAdministrator/enrichment-mcp/badge" alt="Enrichment Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.